### PR TITLE
WIP: Add new functionality to `IReceiver`

### DIFF
--- a/contracts/reference-impl/Receiver.sol
+++ b/contracts/reference-impl/Receiver.sol
@@ -92,8 +92,8 @@ contract Receiver is IReceiver {
         blockHashProverCopy[bhpPointerId] = bhpCopy;
     }
 
-    // todo: natspec
-    // we have an extra return value so the last prover can be used to verify the storage proof in verifyRemoteSlot
+    /// @dev Verify the block hash of a remote chain and return the last prover used to verify it.
+    ///      Returning the last prover is useful for verifying storage slots.
     function _verifyRemoteBlockHashInternal(RemoteReadBlockHashArgs calldata readArgs)
         internal
         view

--- a/contracts/reference-impl/Receiver.sol
+++ b/contracts/reference-impl/Receiver.sol
@@ -12,13 +12,13 @@ contract Receiver is IReceiver {
     mapping(bytes32 => IBlockHashProver) public blockHashProverCopy;
 
     /// @inheritdoc IReceiver
-    function verifyBroadcastMessage(RemoteReadArgs calldata broadcasterReadArgs, bytes32 message, address publisher)
-        external
-        view
-        returns (bytes32, uint256)
-    {
+    function verifyBroadcastMessage(
+        RemoteReadStorageSlotArgs calldata broadcasterReadArgs,
+        bytes32 message,
+        address publisher
+    ) external view returns (bytes32, uint256) {
         // read the message slot from the broadcaster
-        (bytes32 broadcasterId, uint256 messageSlot, bytes32 slotValue) = _readRemoteSlot(broadcasterReadArgs);
+        (bytes32 broadcasterId, uint256 messageSlot, bytes32 slotValue) = verifyRemoteSlot(broadcasterReadArgs);
 
         // ensure slotValue is non-zero
         require(slotValue != 0, "broadcast message not found");
@@ -33,15 +33,50 @@ contract Receiver is IReceiver {
         return (broadcasterId, uint256(slotValue));
     }
 
+    /// @notice Iterate over BHP's to obtain the block hash of a remote chain and finally read a storage slot.
+    function verifyRemoteSlot(RemoteReadStorageSlotArgs calldata readArgs)
+        public
+        view
+        returns (bytes32 remoteAccountId, uint256 slot, bytes32 slotValue)
+    {
+        require(
+            readArgs.blockHashArgs.route.length == readArgs.blockHashArgs.bhpInputs.length,
+            "route.length must equal blockHashProverInputs.length"
+        );
+
+        require(readArgs.blockHashArgs.route.length > 0, "route must have at least one element");
+
+        // get the block hash of the remote chain and the last prover used to verify it
+        bytes32 blockHash;
+        IBlockHashProver lastProver;
+        (remoteAccountId, blockHash, lastProver) = _verifyRemoteBlockHashInternal(readArgs.blockHashArgs);
+
+        // now that the block hash has been obtained,
+        // use the last prover to verify proofs to read the slot
+        address remoteAccount;
+        (remoteAccount, slot, slotValue) = lastProver.verifyStorageSlot(blockHash, readArgs.storageProof);
+
+        // finally, calculate and set the remoteAccountId by adding the remoteAccount to the accumulator
+        remoteAccountId = _acc(remoteAccountId, remoteAccount);
+    }
+
+    function verifyRemoteBlockHash(RemoteReadBlockHashArgs calldata readArgs)
+        external
+        view
+        returns (bytes32 routeId, bytes32 blockHash)
+    {
+        (routeId, blockHash,) = _verifyRemoteBlockHashInternal(readArgs);
+    }
+
     /// @inheritdoc IReceiver
-    function updateBlockHashProverCopy(RemoteReadArgs calldata bhpPointerReadArgs, IBlockHashProver bhpCopy)
+    function updateBlockHashProverCopy(RemoteReadStorageSlotArgs calldata bhpPointerReadArgs, IBlockHashProver bhpCopy)
         external
         returns (bytes32 bhpPointerId)
     {
         // read the block hash prover pointer slot
         uint256 slot;
         bytes32 bhpCodeHash;
-        (bhpPointerId, slot, bhpCodeHash) = _readRemoteSlot(bhpPointerReadArgs);
+        (bhpPointerId, slot, bhpCodeHash) = verifyRemoteSlot(bhpPointerReadArgs);
 
         // ensure the slot is the correct slot
         require(slot == BLOCK_HASH_PROVER_POINTER_SLOT, "slot must match BLOCK_HASH_PROVER_POINTER_SLOT");
@@ -57,11 +92,12 @@ contract Receiver is IReceiver {
         blockHashProverCopy[bhpPointerId] = bhpCopy;
     }
 
-    /// @notice Iterate over BHP's to obtain the block hash of a remote chain and finally read a storage slot.
-    function _readRemoteSlot(RemoteReadArgs calldata readArgs)
+    // todo: natspec
+    // we have an extra return value so the last prover can be used to verify the storage proof in verifyRemoteSlot
+    function _verifyRemoteBlockHashInternal(RemoteReadBlockHashArgs calldata readArgs)
         internal
         view
-        returns (bytes32 remoteAccountId, uint256 slot, bytes32 slotValue)
+        returns (bytes32 routeId, bytes32 blockHash, IBlockHashProver prover)
     {
         require(
             readArgs.route.length == readArgs.bhpInputs.length, "route.length must equal blockHashProverInputs.length"
@@ -70,11 +106,9 @@ contract Receiver is IReceiver {
         require(readArgs.route.length > 0, "route must have at least one element");
 
         // iterate over the BHP's to get the block hash of the remote chain
-        IBlockHashProver prover;
-        bytes32 blockHash;
         for (uint256 i = 0; i < readArgs.route.length; i++) {
             // add the BHPPointer to the accumulator
-            remoteAccountId = _acc(remoteAccountId, readArgs.route[i]);
+            routeId = _acc(routeId, readArgs.route[i]);
 
             if (i == 0) {
                 // the first pointer in the route is handled specially.
@@ -83,19 +117,11 @@ contract Receiver is IReceiver {
                 blockHash = prover.getTargetBlockHash(readArgs.bhpInputs[i]);
             } else {
                 // get the prover copy from storage, ensure it exists, and verify the block hash
-                prover = blockHashProverCopy[remoteAccountId];
+                prover = blockHashProverCopy[routeId];
                 require(address(prover) != address(0), "prover copy not found");
                 blockHash = prover.verifyTargetBlockHash(blockHash, readArgs.bhpInputs[i]);
             }
         }
-
-        // now that the block hash has been obtained,
-        // use the last prover to verify proofs to read the slot
-        address remoteAccount;
-        (remoteAccount, slot, slotValue) = prover.verifyStorageSlot(blockHash, readArgs.storageProof);
-
-        // finally, calculate and set the remoteAccountId by adding the remoteAccount to the accumulator
-        remoteAccountId = _acc(remoteAccountId, remoteAccount);
     }
 
     function _acc(bytes32 acc, address addr) internal pure returns (bytes32) {

--- a/contracts/standard/burn-mint/Minter.sol
+++ b/contracts/standard/burn-mint/Minter.sol
@@ -34,9 +34,10 @@ contract Minter {
     }
 
     /// @notice Mint the tokens when a message is received.
-    function mintTokens(IReceiver.RemoteReadArgs calldata broadcasterReadArgs, BurnMessage calldata messageData)
-        external
-    {
+    function mintTokens(
+        IReceiver.RemoteReadStorageSlotArgs calldata broadcasterReadArgs,
+        BurnMessage calldata messageData
+    ) external {
         // calculate the message from the data
         bytes32 message = keccak256(abi.encode(messageData));
 

--- a/contracts/standard/interfaces/IReceiver.sol
+++ b/contracts/standard/interfaces/IReceiver.sol
@@ -5,31 +5,43 @@ import {IBlockHashProver} from "./IBlockHashProver.sol";
 
 /// @notice Reads messages from a broadcaster.
 interface IReceiver {
-    /// @notice Arguments required to read storage of an account on a remote chain.
-    /// @dev    The storage proof is always for a single slot, if the proof is for multiple slots the IReceiver MUST revert
-    /// @param  route The home chain addresses of the BlockHashProverPointers along the route to the remote chain.
-    /// @param  bhpInputs The inputs to the BlockHashProver / BlockHashProverCopies.
-    /// @param  storageProof Proof passed to the last BlockHashProver / BlockHashProverCopy
-    ///                      to verify a storage slot given a target block hash.
-    struct RemoteReadArgs {
+    // todo: natspec
+    struct RemoteReadBlockHashArgs {
         address[] route;
         bytes[] bhpInputs;
+    }
+
+    // todo: natspec
+    struct RemoteReadStorageSlotArgs {
+        RemoteReadBlockHashArgs blockHashArgs;
         bytes storageProof;
     }
 
     /// @notice Reads a broadcast message from a remote chain.
-    /// @param  broadcasterReadArgs A RemoteReadArgs object:
+    /// @param  broadcasterReadArgs A RemoteReadStorageSlotArgs object:
     ///         - The route points to the broadcasting chain
-    ///         - The account proof is for the broadcaster's account
-    ///         - The storage proof is for the message slot
+    ///         - The storage proof is for the broadcaster's message slot
     /// @param  message The message to read.
     /// @param  publisher The address of the publisher who broadcast the message.
     /// @return broadcasterId The broadcaster's unique identifier.
     /// @return timestamp The timestamp when the message was broadcast.
-    function verifyBroadcastMessage(RemoteReadArgs calldata broadcasterReadArgs, bytes32 message, address publisher)
+    function verifyBroadcastMessage(
+        RemoteReadStorageSlotArgs calldata broadcasterReadArgs,
+        bytes32 message,
+        address publisher
+    ) external view returns (bytes32 broadcasterId, uint256 timestamp);
+
+    // todo: natspec
+    function verifyRemoteSlot(RemoteReadStorageSlotArgs calldata readArgs)
         external
         view
-        returns (bytes32 broadcasterId, uint256 timestamp);
+        returns (bytes32 remoteAccountId, uint256 slot, bytes32 slotValue);
+
+    // todo: natspec
+    function verifyRemoteBlockHash(RemoteReadBlockHashArgs calldata readArgs)
+        external
+        view
+        returns (bytes32 routeId, bytes32 blockHash);
 
     /// @notice Updates the block hash prover copy in storage.
     ///         Checks that BlockHashProverCopy has the same code hash as stored in the BlockHashProverPointer
@@ -40,7 +52,7 @@ interface IReceiver {
     ///         - The storage proof is for the BLOCK_HASH_PROVER_POINTER_SLOT
     /// @param  bhpCopy The BlockHashProver copy on the local chain.
     /// @return bhpPointerId The ID of the BlockHashProverPointer
-    function updateBlockHashProverCopy(RemoteReadArgs calldata bhpPointerReadArgs, IBlockHashProver bhpCopy)
+    function updateBlockHashProverCopy(RemoteReadStorageSlotArgs calldata bhpPointerReadArgs, IBlockHashProver bhpCopy)
         external
         returns (bytes32 bhpPointerId);
 

--- a/contracts/standard/interfaces/IReceiver.sol
+++ b/contracts/standard/interfaces/IReceiver.sol
@@ -5,13 +5,17 @@ import {IBlockHashProver} from "./IBlockHashProver.sol";
 
 /// @notice Reads messages from a broadcaster.
 interface IReceiver {
-    // todo: natspec
+    /// @notice Arguments required to read and verify the block hash of a remote chain.
+    /// @param  route The home chain addresses of the BlockHashProverPointers along the route to the remote chain.
+    /// @param  bhpInputs The inputs to the BlockHashProver / BlockHashProverCopies.
     struct RemoteReadBlockHashArgs {
         address[] route;
         bytes[] bhpInputs;
     }
 
-    // todo: natspec
+    /// @notice Arguments required to read and verify a storage slot of an account on a remote chain.
+    /// @param  blockHashArgs The arguments required to read and verify the block hash of a remote chain.
+    /// @param  storageProof Proof passed to the last BlockHashProver / BlockHashProverCopy to verify a storage slot given a target block hash.
     struct RemoteReadStorageSlotArgs {
         RemoteReadBlockHashArgs blockHashArgs;
         bytes storageProof;
@@ -31,13 +35,23 @@ interface IReceiver {
         address publisher
     ) external view returns (bytes32 broadcasterId, uint256 timestamp);
 
-    // todo: natspec
+    /// @notice Reads a storage slot of an account on a remote chain.
+    /// @param  readArgs A RemoteReadStorageSlotArgs object:
+    ///         - The route points to the remote chain
+    ///         - The storage proof is for the desired slot
+    /// @return remoteAccountId The account ID of the remote account.
+    /// @return slot The slot number.
+    /// @return slotValue The value of the slot.
     function verifyRemoteSlot(RemoteReadStorageSlotArgs calldata readArgs)
         external
         view
         returns (bytes32 remoteAccountId, uint256 slot, bytes32 slotValue);
 
-    // todo: natspec
+    /// @notice Reads the block hash of a remote chain.
+    /// @param  readArgs A RemoteReadBlockHashArgs object:
+    ///         - The route points to the remote chain
+    /// @return routeId The ID of the last BlockHashProverPointer in the route.
+    /// @return blockHash The block hash of the remote chain.
     function verifyRemoteBlockHash(RemoteReadBlockHashArgs calldata readArgs)
         external
         view

--- a/standard/README-template.md
+++ b/standard/README-template.md
@@ -159,6 +159,8 @@ BlockHashProverCopies are exact copies of BlockHashProvers deployed on non-home 
 
 The Receiver is responsible for verifying 32 byte messages deposited in Broadcasters on other chains. The caller provides the Receiver with a route to the remote account and proof to verify the route.
 
+In addition to verifying messages sent through Broadcaster contracts, the Receiver also provides functions to verify arbitrary remote storage slots and remote block hashes.
+
 <div align="center">
 <img src="../assets/erc-7888/receiving.svg" alt="Figure 6" style="width:80%"/>
 

--- a/standard/README.md
+++ b/standard/README.md
@@ -230,6 +230,8 @@ BlockHashProverCopies are exact copies of BlockHashProvers deployed on non-home 
 
 The Receiver is responsible for verifying 32 byte messages deposited in Broadcasters on other chains. The caller provides the Receiver with a route to the remote account and proof to verify the route.
 
+In addition to verifying messages sent through Broadcaster contracts, the Receiver also provides functions to verify arbitrary remote storage slots and remote block hashes.
+
 <div align="center">
 <img src="../assets/erc-7888/receiving.svg" alt="Figure 6" style="width:80%"/>
 

--- a/standard/README.md
+++ b/standard/README.md
@@ -247,31 +247,43 @@ The calls in Figure 6 perform the following operations:
 ```solidity
 /// @notice Reads messages from a broadcaster.
 interface IReceiver {
-    /// @notice Arguments required to read storage of an account on a remote chain.
-    /// @dev    The storage proof is always for a single slot, if the proof is for multiple slots the IReceiver MUST revert
-    /// @param  route The home chain addresses of the BlockHashProverPointers along the route to the remote chain.
-    /// @param  bhpInputs The inputs to the BlockHashProver / BlockHashProverCopies.
-    /// @param  storageProof Proof passed to the last BlockHashProver / BlockHashProverCopy
-    ///                      to verify a storage slot given a target block hash.
-    struct RemoteReadArgs {
+    // todo: natspec
+    struct RemoteReadBlockHashArgs {
         address[] route;
         bytes[] bhpInputs;
+    }
+
+    // todo: natspec
+    struct RemoteReadStorageSlotArgs {
+        RemoteReadBlockHashArgs blockHashArgs;
         bytes storageProof;
     }
 
     /// @notice Reads a broadcast message from a remote chain.
-    /// @param  broadcasterReadArgs A RemoteReadArgs object:
+    /// @param  broadcasterReadArgs A RemoteReadStorageSlotArgs object:
     ///         - The route points to the broadcasting chain
-    ///         - The account proof is for the broadcaster's account
-    ///         - The storage proof is for the message slot
+    ///         - The storage proof is for the broadcaster's message slot
     /// @param  message The message to read.
     /// @param  publisher The address of the publisher who broadcast the message.
     /// @return broadcasterId The broadcaster's unique identifier.
     /// @return timestamp The timestamp when the message was broadcast.
-    function verifyBroadcastMessage(RemoteReadArgs calldata broadcasterReadArgs, bytes32 message, address publisher)
+    function verifyBroadcastMessage(
+        RemoteReadStorageSlotArgs calldata broadcasterReadArgs,
+        bytes32 message,
+        address publisher
+    ) external view returns (bytes32 broadcasterId, uint256 timestamp);
+
+    // todo: natspec
+    function verifyRemoteSlot(RemoteReadStorageSlotArgs calldata readArgs)
         external
         view
-        returns (bytes32 broadcasterId, uint256 timestamp);
+        returns (bytes32 remoteAccountId, uint256 slot, bytes32 slotValue);
+
+    // todo: natspec
+    function verifyRemoteBlockHash(RemoteReadBlockHashArgs calldata readArgs)
+        external
+        view
+        returns (bytes32 routeId, bytes32 blockHash);
 
     /// @notice Updates the block hash prover copy in storage.
     ///         Checks that BlockHashProverCopy has the same code hash as stored in the BlockHashProverPointer
@@ -282,7 +294,7 @@ interface IReceiver {
     ///         - The storage proof is for the BLOCK_HASH_PROVER_POINTER_SLOT
     /// @param  bhpCopy The BlockHashProver copy on the local chain.
     /// @return bhpPointerId The ID of the BlockHashProverPointer
-    function updateBlockHashProverCopy(RemoteReadArgs calldata bhpPointerReadArgs, IBlockHashProver bhpCopy)
+    function updateBlockHashProverCopy(RemoteReadStorageSlotArgs calldata bhpPointerReadArgs, IBlockHashProver bhpCopy)
         external
         returns (bytes32 bhpPointerId);
 
@@ -448,9 +460,10 @@ contract Minter {
     }
 
     /// @notice Mint the tokens when a message is received.
-    function mintTokens(IReceiver.RemoteReadArgs calldata broadcasterReadArgs, BurnMessage calldata messageData)
-        external
-    {
+    function mintTokens(
+        IReceiver.RemoteReadStorageSlotArgs calldata broadcasterReadArgs,
+        BurnMessage calldata messageData
+    ) external {
         // calculate the message from the data
         bytes32 message = keccak256(abi.encode(messageData));
 

--- a/standard/README.md
+++ b/standard/README.md
@@ -247,13 +247,17 @@ The calls in Figure 6 perform the following operations:
 ```solidity
 /// @notice Reads messages from a broadcaster.
 interface IReceiver {
-    // todo: natspec
+    /// @notice Arguments required to read and verify the block hash of a remote chain.
+    /// @param  route The home chain addresses of the BlockHashProverPointers along the route to the remote chain.
+    /// @param  bhpInputs The inputs to the BlockHashProver / BlockHashProverCopies.
     struct RemoteReadBlockHashArgs {
         address[] route;
         bytes[] bhpInputs;
     }
 
-    // todo: natspec
+    /// @notice Arguments required to read and verify a storage slot of an account on a remote chain.
+    /// @param  blockHashArgs The arguments required to read and verify the block hash of a remote chain.
+    /// @param  storageProof Proof passed to the last BlockHashProver / BlockHashProverCopy to verify a storage slot given a target block hash.
     struct RemoteReadStorageSlotArgs {
         RemoteReadBlockHashArgs blockHashArgs;
         bytes storageProof;
@@ -273,13 +277,23 @@ interface IReceiver {
         address publisher
     ) external view returns (bytes32 broadcasterId, uint256 timestamp);
 
-    // todo: natspec
+    /// @notice Reads a storage slot of an account on a remote chain.
+    /// @param  readArgs A RemoteReadStorageSlotArgs object:
+    ///         - The route points to the remote chain
+    ///         - The storage proof is for the desired slot
+    /// @return remoteAccountId The account ID of the remote account.
+    /// @return slot The slot number.
+    /// @return slotValue The value of the slot.
     function verifyRemoteSlot(RemoteReadStorageSlotArgs calldata readArgs)
         external
         view
         returns (bytes32 remoteAccountId, uint256 slot, bytes32 slotValue);
 
-    // todo: natspec
+    /// @notice Reads the block hash of a remote chain.
+    /// @param  readArgs A RemoteReadBlockHashArgs object:
+    ///         - The route points to the remote chain
+    /// @return routeId The ID of the last BlockHashProverPointer in the route.
+    /// @return blockHash The block hash of the remote chain.
     function verifyRemoteBlockHash(RemoteReadBlockHashArgs calldata readArgs)
         external
         view


### PR DESCRIPTION
to make it more "light clientish" by adding another function on the receiver to verify block hashes instead of broadcaster storage slots

also added a `verifyRemoteSlot` function, which may or may not be useful. TBD