### PR TITLE
add event to pointer

### DIFF
--- a/contracts/reference-impl/BlockHashProverPointer.sol
+++ b/contracts/reference-impl/BlockHashProverPointer.sol
@@ -16,6 +16,7 @@ contract BlockHashProverPointer is IBlockHashProverPointer, Ownable {
     function setBHP(address bhp) external onlyOwner {
         implementationAddress = bhp;
         _storeCodeHash(bhp.codehash);
+        emit ProverUpdated(bhp);
     }
 
     /// @dev Return the code hash stored in BLOCK_HASH_PROVER_POINTER_SLOT.

--- a/contracts/standard/interfaces/IBlockHashProverPointer.sol
+++ b/contracts/standard/interfaces/IBlockHashProverPointer.sol
@@ -4,10 +4,15 @@ pragma solidity >=0.6.0 <0.9.0;
 /// @title  IBlockHashProverPointer
 /// @notice Keeps the code hash of the latest version of a block hash prover.
 ///         MUST store the code hash in storage slot BLOCK_HASH_PROVER_POINTER_SLOT.
+///         MUST emit ProverUpdated when the prover is updated.
 ///         Different versions of the prover MUST have the same home and target chains.
 ///         If the pointer's prover is updated, the new prover MUST have a higher IBlockHashProver::version() than the old one.
 ///         These pointers are always referred to by their address on their home chain.
 interface IBlockHashProverPointer {
+    /// @notice Emitted when the prover is updated.
+    /// @param newProver The address of the new prover.
+    event ProverUpdated(address indexed newProver);
+
     /// @notice Return the code hash of the latest version of the prover.
     function implementationCodeHash() external view returns (bytes32);
 

--- a/standard/README-template.md
+++ b/standard/README-template.md
@@ -98,6 +98,8 @@ When updating a BlockHashProverPointer to point to a new BlockHashProver impleme
 
 BlockHashProverPointers MUST store the code hash of the BlockHashProver implementation in slot `BLOCK_HASH_PROVER_POINTER_SLOT`.
 
+BlockHashProverPointers MUST emit the `ProverUpdated` event when the prover is updated.
+
 <div align="center">
 <img src="../assets/erc-7888/pointer.svg" alt="Figure 3" style="width:30%"/>
 

--- a/standard/README.md
+++ b/standard/README.md
@@ -157,6 +157,8 @@ When updating a BlockHashProverPointer to point to a new BlockHashProver impleme
 
 BlockHashProverPointers MUST store the code hash of the BlockHashProver implementation in slot `BLOCK_HASH_PROVER_POINTER_SLOT`.
 
+BlockHashProverPointers MUST emit the `ProverUpdated` event when the prover is updated.
+
 <div align="center">
 <img src="../assets/erc-7888/pointer.svg" alt="Figure 3" style="width:30%"/>
 
@@ -167,10 +169,15 @@ BlockHashProverPointers MUST store the code hash of the BlockHashProver implemen
 /// @title  IBlockHashProverPointer
 /// @notice Keeps the code hash of the latest version of a block hash prover.
 ///         MUST store the code hash in storage slot BLOCK_HASH_PROVER_POINTER_SLOT.
+///         MUST emit ProverUpdated when the prover is updated.
 ///         Different versions of the prover MUST have the same home and target chains.
 ///         If the pointer's prover is updated, the new prover MUST have a higher IBlockHashProver::version() than the old one.
 ///         These pointers are always referred to by their address on their home chain.
 interface IBlockHashProverPointer {
+    /// @notice Emitted when the prover is updated.
+    /// @param newProver The address of the new prover.
+    event ProverUpdated(address indexed newProver);
+
     /// @notice Return the code hash of the latest version of the prover.
     function implementationCodeHash() external view returns (bytes32);
 


### PR DESCRIPTION
to aid in verification of the increasing prover versions invariant, add a mandatory event to the pointer. without this it is difficult to verify that there isn't a prover lurking in history with a higher version than the current prover. 